### PR TITLE
Change interface for RaiseBomb

### DIFF
--- a/lib/stink_bomb.rb
+++ b/lib/stink_bomb.rb
@@ -4,8 +4,10 @@ require 'stink_bomb/configuration'
 require 'stink_bomb/raise_bomb'
 
 module StinkBomb
+  class StinkyCodeError < StandardError; end
+
   def self.create(datetime, message: nil)
-    StinkBomb::RaiseBomb.new(datetime, message: message).trigger
+    StinkBomb::RaiseBomb.new.trigger(datetime, message: message)
   end
 
   def self.configuration

--- a/lib/stink_bomb/raise_bomb.rb
+++ b/lib/stink_bomb/raise_bomb.rb
@@ -3,14 +3,17 @@ module StinkBomb
     attr_accessor :time
     attr_writer :message
 
-    def initialize(time, message: nil)
-      self.time = parse(time)
-      self.message = message || StinkBomb.configuration.message
+    def initialize(error_class: StinkyCodeError)
+      @error_class = error_class
     end
 
-    def trigger
-      fail message if !production? && past_time?
+    def trigger(time, message: StinkBomb.configuration.message)
+      self.time = parse(time)
+
+      fail error(message) if !production? && past_time?
     end
+
+  private
 
     def parse(time)
       time = Time.parse(time) if time.is_a?(String)
@@ -29,8 +32,8 @@ module StinkBomb
       Time.now.utc > time.utc
     end
 
-    def message
-      @message.gsub('{time}', time.to_s)
+    def error(message)
+      @error_class.new(message.gsub('{time}', time.to_s))
     end
   end
 end

--- a/spec/lib/stink_bomb/raise_bomb_spec.rb
+++ b/spec/lib/stink_bomb/raise_bomb_spec.rb
@@ -1,22 +1,36 @@
 module StinkBomb
   describe RaiseBomb, '#initialize' do
-    it 'raises an error if the parameter is not a date or a string' do
+    it 'accepts an error class to raise' do
       expect do
-        RaiseBomb.new(1)
-      end.to raise_error('Parameter has to be a Time, Date, or a String')
+        RaiseBomb.new(error_class: StinkyTestError).trigger(Date.today - 1)
+      end.to raise_error(StinkyTestError, /Your code stinks!/)
+    end
+
+    it 'raises a StinkyCodeError by default' do
+      expect do
+        RaiseBomb.new.trigger(Date.today - 1)
+      end.to raise_error(StinkyCodeError, /Your code stinks!/)
     end
   end
 
   describe RaiseBomb, '#trigger' do
+    let(:raise_bomb) { RaiseBomb.new }
+
+    it 'raises an error if the parameter is not a date or a string' do
+      expect do
+        raise_bomb.trigger(1)
+      end.to raise_error('Parameter has to be a Time, Date, or a String')
+    end
+
     it 'does nothing if tomorrow is given' do
       expect do
-        RaiseBomb.new(Date.today + 1).trigger
+        raise_bomb.trigger(Date.today + 1)
       end.not_to raise_error
     end
 
     it 'does nothing if now + epsilon is given' do
       expect do
-        RaiseBomb.new(Time.now.getlocal + 1).trigger
+        raise_bomb.trigger(Time.now.getlocal + 1)
       end.not_to raise_error
     end
 
@@ -24,21 +38,21 @@ module StinkBomb
       expect(ENV).to receive(:[]).with('RAILS_ENV').and_return('production')
 
       expect do
-        RaiseBomb.new(Date.today - 1).trigger
+        raise_bomb.trigger(Date.today - 1)
       end.not_to raise_error
     end
 
     it 'raises a custom message when specified' do
       yesterday = Date.today - 1
       expect do
-        RaiseBomb.new(yesterday, message: 'Smells like poo').trigger
+        raise_bomb.trigger(yesterday, message: 'Smells like poo')
       end.to raise_error(/Smells like poo/)
     end
 
     it 'raises an error if the given date is after today' do
       yesterday = Date.today - 1
       expect do
-        RaiseBomb.new(yesterday).trigger
+        raise_bomb.trigger(yesterday)
       end.to raise_error(/stinks! It was supposed to be fixed by #{yesterday}/)
     end
   end

--- a/spec/lib/stink_bomb_spec.rb
+++ b/spec/lib/stink_bomb_spec.rb
@@ -1,9 +1,9 @@
 describe StinkBomb do
   describe '.create' do
     it 'creates an instance of Bomb with the parameters' do
-      receive_expected = receive(:new).with('01/01/2100', message: nil)
-      expect(StinkBomb::RaiseBomb).to receive_expected.and_call_original
-      expect_any_instance_of(StinkBomb::RaiseBomb).to receive(:trigger)
+      bomb_class = StinkBomb::RaiseBomb
+      receive_expected = receive(:trigger).with('01/01/2100', message: nil)
+      expect_any_instance_of(bomb_class).to receive_expected.and_call_original
       StinkBomb.create('01/01/2100')
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ if ENV['CI']
     Coveralls::SimpleCov::Formatter
   ]
 end
+SimpleCov.minimum_coverage 100
 SimpleCov.start { add_filter '/spec/' }
 
 require_relative '../lib/stink_bomb'
@@ -14,3 +15,5 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end
+
+class StinkyTestError < StandardError; end


### PR DESCRIPTION
Because we're going to want to instantiate the bombs at configure time instead
of runtime, I'm changing the interface to put the time and message inside the
call to `#trigger`. This also adds `StinkyCodeError` instead of just raising
a `RuntimeError`.
