### PR TITLE
remove references to production

### DIFF
--- a/lib/stink_bomb/raise_bomb.rb
+++ b/lib/stink_bomb/raise_bomb.rb
@@ -10,7 +10,7 @@ module StinkBomb
     def trigger(time, message: StinkBomb.configuration.message)
       self.time = parse(time)
 
-      fail error(message) if !production? && past_time?
+      fail error(message) if past_time?
     end
 
   private
@@ -22,10 +22,6 @@ module StinkBomb
       end
 
       time.to_time
-    end
-
-    def production?
-      ENV['RAILS_ENV'] == 'production' || ENV['RACK_ENV'] == 'production'
     end
 
     def past_time?

--- a/spec/lib/stink_bomb/raise_bomb_spec.rb
+++ b/spec/lib/stink_bomb/raise_bomb_spec.rb
@@ -34,14 +34,6 @@ module StinkBomb
       end.not_to raise_error
     end
 
-    it 'does not raise an error in production' do
-      expect(ENV).to receive(:[]).with('RAILS_ENV').and_return('production')
-
-      expect do
-        raise_bomb.trigger(Date.today - 1)
-      end.not_to raise_error
-    end
-
     it 'raises a custom message when specified' do
       yesterday = Date.today - 1
       expect do


### PR DESCRIPTION
This can be handled inside the app rather than the gem.